### PR TITLE
Fixed merging with _methodParams in ConstructAppAgnosticUrl method

### DIFF
--- a/ServiceRequest.php
+++ b/ServiceRequest.php
@@ -137,7 +137,7 @@ class ServiceRequest{
 								'ts' => gmdate("YmdHis")
 							);
 
-		array_merge($parameterMap,$this->_methodParams);
+        $parameterMap = array_merge($parameterMap,$this->_methodParams);
 		foreach($this->_methodParams as $key => $value)
 		{
 			$parameterMap[$key] = $value;


### PR DESCRIPTION
_methodParams is not using now. Therefore impossible to set for example json dataformat variable.